### PR TITLE
fix Result方法在测试报NPE的问题并增加获取Result对象数据的公开发方法

### DIFF
--- a/wk-framework/src/main/java/cn/wizzer/framework/base/Result.java
+++ b/wk-framework/src/main/java/cn/wizzer/framework/base/Result.java
@@ -40,7 +40,11 @@ public class Result {
 
     public Result(int code, String msg, Object data) {
         this.code = code;
-        this.msg = Strings.isBlank(msg) ? "" : Mvcs.getActionContext().getRequest() == null ? msg : Mvcs.getMessage(Mvcs.getActionContext().getRequest(), msg);
+        if (Strings.isBlank(msg) || Mvcs.getActionContext() == null || Mvcs.getActionContext().getRequest() == null || Mvcs.getMessage(Mvcs.getActionContext().getRequest(), msg) == null) {
+            this.msg = "";
+        } else {
+            this.msg = Mvcs.getMessage(Mvcs.getActionContext().getRequest(), msg);
+        }
         this.data = data;
     }
 
@@ -66,6 +70,19 @@ public class Result {
 
     public static Result error() {
         return new Result(1, "globals.result.error", null);
+    }
+    
+    
+    public int getCode() {
+        return code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public Object getData() {
+        return data;
     }
 
     @Override


### PR DESCRIPTION
NPE是由Mvcs获取context及request对象为空导致的
增加公开方法是为了方便测试做断言处理