### PR TITLE
使用JedisAgenAccessTokenStore; 删除多余junit依赖

### DIFF
--- a/wk-app/wk-nb-service-cms/pom.xml
+++ b/wk-app/wk-nb-service-cms/pom.xml
@@ -135,11 +135,6 @@
             <artifactId>nutzboot-starter-logback-exts</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-service-sys/pom.xml
+++ b/wk-app/wk-nb-service-sys/pom.xml
@@ -153,11 +153,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-service-wx/pom.xml
+++ b/wk-app/wk-nb-service-wx/pom.xml
@@ -135,11 +135,6 @@
             <artifactId>nutzboot-starter-logback-exts</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-task/pom.xml
+++ b/wk-app/wk-nb-task/pom.xml
@@ -105,11 +105,6 @@
             <artifactId>nutzboot-starter-logback-exts</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-web-api/pom.xml
+++ b/wk-app/wk-nb-web-api/pom.xml
@@ -134,11 +134,6 @@
             <artifactId>nutzboot-starter-ftp</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-web-platform/pom.xml
+++ b/wk-app/wk-nb-web-platform/pom.xml
@@ -175,11 +175,6 @@
             <artifactId>nutzboot-starter-ftp</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-web-platform/src/main/java/cn/wizzer/app/web/commons/ext/wx/WxService.java
+++ b/wk-app/wk-nb-web-platform/src/main/java/cn/wizzer/app/web/commons/ext/wx/WxService.java
@@ -5,14 +5,14 @@ import cn.wizzer.app.wx.modules.models.Wx_config;
 import cn.wizzer.app.wx.modules.services.WxConfigService;
 import com.alibaba.dubbo.config.annotation.Reference;
 import org.nutz.dao.Cnd;
+import org.nutz.integration.jedis.JedisAgent;
 import org.nutz.ioc.loader.annotation.Inject;
 import org.nutz.ioc.loader.annotation.IocBean;
 import org.nutz.log.Log;
 import org.nutz.log.Logs;
-import org.nutz.weixin.at.impl.RedisAccessTokenStore;
+import org.nutz.weixin.at.impl.JedisAgenAccessTokenStore;
 import org.nutz.weixin.impl.WxApi2Impl;
 import org.nutz.weixin.spi.WxApi2;
-import redis.clients.jedis.JedisPool;
 
 /**
  * Created by wizzer on 2018/3/17.
@@ -24,15 +24,13 @@ public class WxService {
     @Reference
     private WxConfigService wxConfigService;
     @Inject
-    private JedisPool jedisPool;
+    private JedisAgent jedisAgent;
 
     public synchronized WxApi2 getWxApi2(String wxid) {
         WxApi2Impl wxApi2 = Globals.WxMap.getAs(wxid, WxApi2Impl.class);
         if (wxApi2 == null) {
             Wx_config appInfo = wxConfigService.fetch(Cnd.where("id", "=", wxid));
-            RedisAccessTokenStore redisAccessTokenStore = new RedisAccessTokenStore();//如果是集群部署请启用RedisAccessTokenStore
-            redisAccessTokenStore.setTokenKey("nutzwk:wx:token:" + wxid);
-            redisAccessTokenStore.setJedisPool(jedisPool);
+            JedisAgenAccessTokenStore redisAccessTokenStore = new JedisAgenAccessTokenStore("nutzwk:wx:token:" + wxid,jedisAgent);
             wxApi2 = new WxApi2Impl();
             wxApi2.setAppid(appInfo.getAppid());
             wxApi2.setAppsecret(appInfo.getAppsecret());

--- a/wk-app/wk-nb-web-vue/pom.xml
+++ b/wk-app/wk-nb-web-vue/pom.xml
@@ -172,11 +172,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
@@ -201,6 +196,7 @@
             <artifactId>nutzboot-starter-ftp</artifactId>
             <version>${nutzboot.version}</version>
         </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/wk-app/wk-nb-web-vue/src/main/java/cn/wizzer/app/web/commons/ext/wx/WxService.java
+++ b/wk-app/wk-nb-web-vue/src/main/java/cn/wizzer/app/web/commons/ext/wx/WxService.java
@@ -5,14 +5,14 @@ import cn.wizzer.app.wx.modules.models.Wx_config;
 import cn.wizzer.app.wx.modules.services.WxConfigService;
 import com.alibaba.dubbo.config.annotation.Reference;
 import org.nutz.dao.Cnd;
+import org.nutz.integration.jedis.JedisAgent;
 import org.nutz.ioc.loader.annotation.Inject;
 import org.nutz.ioc.loader.annotation.IocBean;
 import org.nutz.log.Log;
 import org.nutz.log.Logs;
-import org.nutz.weixin.at.impl.RedisAccessTokenStore;
+import org.nutz.weixin.at.impl.JedisAgenAccessTokenStore;
 import org.nutz.weixin.impl.WxApi2Impl;
 import org.nutz.weixin.spi.WxApi2;
-import redis.clients.jedis.JedisPool;
 
 /**
  * Created by wizzer on 2018/3/17.
@@ -24,15 +24,13 @@ public class WxService {
     @Reference
     private WxConfigService wxConfigService;
     @Inject
-    private JedisPool jedisPool;
+    private JedisAgent jedisAgent;
 
     public synchronized WxApi2 getWxApi2(String wxid) {
         WxApi2Impl wxApi2 = Globals.WxMap.getAs(wxid, WxApi2Impl.class);
         if (wxApi2 == null) {
             Wx_config appInfo = wxConfigService.fetch(Cnd.where("id", "=", wxid));
-            RedisAccessTokenStore redisAccessTokenStore = new RedisAccessTokenStore();//如果是集群部署请启用RedisAccessTokenStore
-            redisAccessTokenStore.setTokenKey("nutzwk:wx:token:" + wxid);
-            redisAccessTokenStore.setJedisPool(jedisPool);
+            JedisAgenAccessTokenStore redisAccessTokenStore = new JedisAgenAccessTokenStore("nutzwk:wx:token:" + wxid,jedisAgent);
             wxApi2 = new WxApi2Impl();
             wxApi2.setAppid(appInfo.getAppid());
             wxApi2.setAppsecret(appInfo.getAppsecret());


### PR DESCRIPTION
1. change: 使用支持redis集群的JedisAgenAccessTokenStore管理wx accessToken
2. delete: 删除junit直接依赖,因为nutzboot-starter-test-junit4已经间接依赖了junit